### PR TITLE
Add cabal.project file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,12 @@ This is a compiler that can:
 
 To clone, run `git clone --recursive https://github.com/diku-kmc/kleenexlang.git`.
 
-Due to dependencies not on Hackage, it is easiest to build in a sandbox. After cloning, cd into project directory and run `cabal sandbox init && cabal sandbox add-source regexps-syntax`. Then pull in dependencies by `cabal install --dependencies-only`.
+To build, run `cabal build`.  You can then run the binary with `cabal
+ run kexc`.  You can install it to e.g. `$HOME/.local/bin` with
 
-To build, run `cabal configure && cabal build`. This will place a binary in `dist/build/kexc/kexc`.
+```
+$ cabal install --install-method=copy --overwrite-policy=always --installdir=$HOME/.local/bin/
+```
 
 ## Use ##
 

--- a/cabal.project
+++ b/cabal.project
@@ -1,0 +1,7 @@
+packages: kexc.cabal
+index-state: 2021-03-03T05:14:22Z
+
+source-repository-package
+    type: git
+    location: https://github.com/diku-kmc/regexps-syntax.git
+    tag: 5c235fc057e25dffc1f5a3ca5a122ce1367ab594


### PR DESCRIPTION
Also adds new README instructions.  These will work with any recent
`cabal-install`.  You still need an older GHC.