### PR TITLE
Work with newer GHC.

### DIFF
--- a/src/KMC/Backtracking.hs
+++ b/src/KMC/Backtracking.hs
@@ -20,7 +20,7 @@ import           Control.Applicative
 import           Control.Monad
 import qualified Data.ByteString as B
 import qualified Data.ByteString.Lazy as L
-import qualified Data.IntMap as M
+import qualified Data.IntMap.Strict as M
 import qualified Data.IntSet as S
 import           Data.Word (Word8)
 
@@ -52,7 +52,7 @@ type Index = Int
 type Marks = M.IntMap S.IntSet
 
 mark :: Name -> Index -> Marks -> Marks
-mark p i = M.insertWith' S.union p (S.singleton i)
+mark p i = M.insertWith S.union p (S.singleton i)
 
 isMarked :: Name -> Index -> Marks -> Bool
 isMarked p i m = maybe False (S.member i) (M.lookup p m)

--- a/src/KMC/Kleenex/Actions.hs
+++ b/src/KMC/Kleenex/Actions.hs
@@ -7,7 +7,6 @@ module KMC.Kleenex.Actions(RegAction(..)
 import           Data.ByteString.Builder
 import           Data.Map (Map, (!))
 import qualified Data.Map as M
-import           Data.Monoid
 import           Data.Word (Word8)
 
 import           KMC.Kleenex.Syntax
@@ -38,9 +37,11 @@ pop r = Action $ \(store, h:stck) -> (M.insert r h store, stck)
 wr :: RegIdent -> Action
 wr r = Action $ \(store, h:stck) -> (M.insert r mempty store, (h <> store!r):stck)
 
+instance Semigroup Action where
+  Action is1 <> Action is2 = Action $ is2 . is1
+
 instance Monoid Action where
   mempty = Action id
-  mappend (Action is1) (Action is2) = Action $ is2 . is1
 
 -- | Interprets an action as a state transformation
 actionSem :: RegAction -> Action

--- a/src/KMC/Kleenex/Desugaring.hs
+++ b/src/KMC/Kleenex/Desugaring.hs
@@ -165,7 +165,7 @@ desugarTerm out t =
                                                ++ [Right $ Pop r]) >>= decl . RSeq
   WriteReg r          -> decl $ RConst (Right (Write r))
   RedirectReg r t1    -> do it <- desugarTerm out t1
-                            [ipush, ipop] <- mapM (decl . RConst . Right) [Push, Pop r]
+                            ~[ipush, ipop] <- mapM (decl . RConst . Right) [Push, Pop r]
                             decl $ RSeq [ipush,it,ipop]
   TermInfo _ t1       -> desugarTerm out t1
   where

--- a/src/KMC/Kleenex/WellFormedness.hs
+++ b/src/KMC/Kleenex/WellFormedness.hs
@@ -11,6 +11,7 @@ import qualified Data.Map as M
 import           Data.Set (Set)
 import qualified Data.Set as S
 import           Text.PrettyPrint
+import           Prelude hiding ((<>))
 
 --------
 -- Types

--- a/src/KMC/Program/Backends/C.hs
+++ b/src/KMC/Program/Backends/C.hs
@@ -16,6 +16,7 @@ import           System.Exit (ExitCode(..))
 import           System.IO
 import           System.Process
 import           Text.PrettyPrint
+import           Prelude hiding ((<>))
 
 import           KMC.Util.Coding
 import           KMC.Program.IL

--- a/src/KMC/SymbolicFST.hs
+++ b/src/KMC/SymbolicFST.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
 module KMC.SymbolicFST
        (FST(..)
        ,Edge

--- a/src/KMC/SymbolicSST.hs
+++ b/src/KMC/SymbolicSST.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE UndecidableInstances #-}
 module KMC.SymbolicSST
        (UpdateString
        ,UpdateStringFunc

--- a/src/KMC/Visualization.hs
+++ b/src/KMC/Visualization.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE TypeSynonymInstances #-}
+{-# LANGUAGE UndecidableInstances #-}
 module KMC.Visualization where
 
 import qualified Data.GraphViz as GV


### PR DESCRIPTION
The only significant changes are related to the Monoid/Semigroup
change that came about in GHC 8.4.1.  With this commit, KMC will need
at least that version of GHC.  Without this commit, it needs one that
is *older*.